### PR TITLE
Update CosmosDB_CogSearch_AzureOpenAI_Tutorial.ipynb - fixed engine configuration 

### DIFF
--- a/Python/CosmosDB-NoSQL_CognitiveSearch/CosmosDB_CogSearch_AzureOpenAI_Tutorial.ipynb
+++ b/Python/CosmosDB-NoSQL_CognitiveSearch/CosmosDB_CogSearch_AzureOpenAI_Tutorial.ipynb
@@ -187,7 +187,7 @@
     "    This will be used to vectorize data and user input for interactions with Azure OpenAI.\n",
     "    '''\n",
     "    response = openai.Embedding.create(\n",
-    "        input=text, engine=\"text-embedding-ada-002\")\n",
+    "        input=text, engine=embeddings_deployment)\n",
     "    embeddings = response['data'][0]['embedding']\n",
     "    time.sleep(0.5) # rest period to avoid rate limiting on AOAI for free tier\n",
     "    return embeddings"


### PR DESCRIPTION
generate_embeddings method used a constant value for engine that is engine="text-embedding-ada-002" without reading the configuration from file. This fixes it and aligns with the generate_completion method