### PR TITLE
Update README.md for Mongo vCore sample repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Table below provides a high level guidance. Please follow the links to the relev
 | Azure data product |Native vector indexing OR Azure Cognitive Search (ACS) | Guidance: repo, blog or docs| 
 |----------|----------|---------------------------------------------|
 |   Azure Database for PostgreSQL |      Native    | Sample in this repo (Python)|
-|   CosmosDB - MongoDB vCore |    Native      | [Docs](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search/), [Blog](https://devblogs.microsoft.com/cosmosdb/introducing-vector-search-in-azure-cosmos-db-for-mongodb-vcore/), [Repo](https://github.com/Azure/Vector-Search-AI-Assistant/tree/mongovcorev2), Sample in this repo (C#, Python) |
+|   CosmosDB - MongoDB vCore |    Native      | [Docs](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/vector-search/), [Blog](https://devblogs.microsoft.com/cosmosdb/introducing-vector-search-in-azure-cosmos-db-for-mongodb-vcore/), [Repo](https://github.com/Azure/Vector-Search-AI-Assistant-MongoDBvCore), Sample in this repo (C#, Python) |
 |   Azure Cache for Redis |      Native    | Sample in this repo (Python)|
 |   CosmosDB - PostgreSQL  |    ACS    |                   Sample in this repo (Python)                         |
 |   CosmosDB - MongoDB |    ACS      |                   Sample in this repo (C#, Python)                          |


### PR DESCRIPTION
Updating link. Moved the MongoDB vCore sample to it's own repository.